### PR TITLE
Developer setup instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+################################
+### TO BUILD IMAGE
+# docker build -t bloom-works/guides-template . 
+#
+### TO RUN SERVER (requires rebuild if files change)
+# docker run -it --rm -p "8080:8080" bloom-works/guides-template
+#
+### TO RUN TERMINAL WITH LOCAL FILES (i.e. for local development with live file mapping)
+#   1. docker run -it --rm -p "8080:8080" -v "$PWD:/app" bloom-works/guides-template bash
+#   2. npm install
+#   3. npm run serve
+################################
+
+# Debian based base image for Node.js
+FROM node:18.16.0 
+
+# Put files in /app
+WORKDIR /app
+COPY . .
+
+# Build the application
+RUN npm install
+
+# Run a server if executing the container (Port 8080 is default)
+ARG PORT=8080
+EXPOSE ${PORT}
+CMD npm run serve --port=${PORT}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
-## Bloom Works Guides Starter Template
-To start project locally, run `npm install` then `npm run serve`
+# Bloom Works Guides Starter Template
+
+## Run Instructions
+
+This requires Docker to be installed and running
+
+1. Build the container: `docker build -t bloom-works/guides-template .`
+1. Start the server: `docker run -it --rm -p "8080:8080" bloom-works/guides-template`
+1. View the site in your browser at [http://localhost:8080](http://localhost:8080)
+
+## Developer Setup
+
+### Docker Version
+
+This sets up the site with a consistent runtime environment, and requires Docker to be installed and running.
+
+1. Navigate to the base of this repo
+1. Build the container: `docker build -t bloom-works/guides-template .`
+1. Start a terminal inside the container: `docker run -it --rm -p "8080:8080" -v "$PWD:/app" bloom-works/guides-template bash`
+1. Install dependencies (first time only or when `package.json` changes): `npm install`
+1. Start server: `npm run serve`
+1. View the site in your browser at [http://localhost:8080](http://localhost:8080)
+
+From here, changes to files locally will rebuild the site.
+
+### Local Version
+
+This uses whatever NPM and Node version you have installed on your machine, and might use fewer system resources than the Docker install (i.e. better for lower powered machines). If something is not working using this setup, use the Docker version to see if the problem exists there.
+
+1. Navigate to the base of this repo
+1. Install dependencies (first time only or when `package.json` changes): `npm install`
+1. Start server: `npm run serve`
+1. View the site in your browser at [http://localhost:8080](http://localhost:8080)
+
+From here, changes to files will rebuild the site.
 
 ### Design
 


### PR DESCRIPTION
Added developer setup instructions and a `Dockerfile`. This should make the build consistent/idempotent.

Contributes to #5 .