### PR TITLE
Modified JS Linter to include eleventy config file

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,19 +1,19 @@
-const { DateTime } = require("luxon");
-const fs = require("fs");
-const pluginRss = require("@11ty/eleventy-plugin-rss");
-const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
-const pluginNavigation = require("@11ty/eleventy-navigation");
-const markdownLibrary = require("./markdown");
+const { DateTime } = require('luxon');
+const fs = require('fs');
+const pluginRss = require('@11ty/eleventy-plugin-rss');
+const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
+const pluginNavigation = require('@11ty/eleventy-navigation');
+const markdownLibrary = require('./markdown');
 
-const GridComponent = require("./_includes/components/Grid");
-const GridColumnComponent = require("./_includes/components/GridColumn");
-const PageHeaderComponent = require("./_includes/components/PageHeader");
-const PaginationComponent = require("./_includes/components/Pagination.js");
-const ResourcePrivateComponent = require("./_includes/components/ResourcePrivate");
-const ResourcePublicComponent = require("./_includes/components/ResourcePublic");
-const ResourceGroupComponent = require("./_includes/components/ResourceGroup");
+const GridComponent = require('./_includes/components/Grid');
+const GridColumnComponent = require('./_includes/components/GridColumn');
+const PageHeaderComponent = require('./_includes/components/PageHeader');
+const PaginationComponent = require('./_includes/components/Pagination.js');
+const ResourcePrivateComponent = require('./_includes/components/ResourcePrivate');
+const ResourcePublicComponent = require('./_includes/components/ResourcePublic');
+const ResourceGroupComponent = require('./_includes/components/ResourceGroup');
 
-module.exports = function(eleventyConfig) {
+module.exports = function (eleventyConfig) {
   // Add plugins
   eleventyConfig.addPlugin(pluginRss);
   eleventyConfig.addPlugin(pluginSyntaxHighlight);
@@ -23,20 +23,20 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.setDataDeepMerge(true);
 
   // Alias `layout: post` to `layout: layouts/post.njk`
-  eleventyConfig.addLayoutAlias("post", "layouts/post.njk");
+  eleventyConfig.addLayoutAlias('post', 'layouts/post.njk');
 
-  eleventyConfig.addFilter("readableDate", dateObj => {
-    return DateTime.fromJSDate(dateObj, {zone: 'utc'}).toFormat("dd LLL yyyy");
+  eleventyConfig.addFilter('readableDate', dateObj => {
+    return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat('dd LLL yyyy');
   });
 
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
   eleventyConfig.addFilter('htmlDateString', (dateObj) => {
-    return DateTime.fromJSDate(dateObj, {zone: 'utc'}).toFormat('yyyy-LL-dd');
+    return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat('yyyy-LL-dd');
   });
 
   // Get the first `n` elements of a collection.
-  eleventyConfig.addFilter("head", (array, n) => {
-    if( n < 0 ) {
+  eleventyConfig.addFilter('head', (array, n) => {
+    if (n < 0) {
       return array.slice(n);
     }
 
@@ -44,18 +44,18 @@ module.exports = function(eleventyConfig) {
   });
 
   // Return the smallest number argument
-  eleventyConfig.addFilter("min", (...numbers) => {
+  eleventyConfig.addFilter('min', (...numbers) => {
     return Math.min.apply(null, numbers);
   });
 
-  eleventyConfig.addFilter("filterTagList", tags => {
+  eleventyConfig.addFilter('filterTagList', tags => {
     // should match the list in tags.njk
-    return (tags || []).filter(tag => ["all", "nav", "post", "posts"].indexOf(tag) === -1);
+    return (tags || []).filter(tag => ['all', 'nav', 'post', 'posts'].indexOf(tag) === -1);
   })
 
   // Create an array of all tags
-  eleventyConfig.addCollection("tagList", function(collection) {
-    let tagSet = new Set();
+  eleventyConfig.addCollection('tagList', function (collection) {
+    const tagSet = new Set();
     collection.getAll().forEach(item => {
       (item.data.tags || []).forEach(tag => tagSet.add(tag));
     });
@@ -64,77 +64,78 @@ module.exports = function(eleventyConfig) {
   });
 
   // Copy the `img` and `css` folders to the output
-  eleventyConfig.addPassthroughCopy("img");
-  eleventyConfig.addPassthroughCopy("css");
+  eleventyConfig.addPassthroughCopy('img');
+  eleventyConfig.addPassthroughCopy('css');
 
   // Customize Markdown library and settings:
-  eleventyConfig.setLibrary("md", markdownLibrary);
+  eleventyConfig.setLibrary('md', markdownLibrary);
 
   // Override Browsersync defaults (used only with --serve)
   eleventyConfig.setBrowserSyncConfig({
     callbacks: {
-      ready: function(err, browserSync) {
-        const content_404 = fs.readFileSync('_site/404.html');
+      ready: function (err, browserSync) {
+        const contentHTML404 = fs.readFileSync('_site/404.html');
+        console.log('Inside 404 error', err);
 
-        browserSync.addMiddleware("*", (req, res) => {
+        browserSync.addMiddleware('*', (req, res) => {
           // Provides the 404 content without redirect.
-          res.writeHead(404, {"Content-Type": "text/html; charset=UTF-8"});
-          res.write(content_404);
+          res.writeHead(404, { 'Content-Type': 'text/html; charset=UTF-8' });
+          res.write(contentHTML404);
           res.end();
         });
-      },
+      }
     },
     ui: false,
     ghostMode: false
   });
 
-  eleventyConfig.addPairedShortcode("Grid", GridComponent);
-  eleventyConfig.addPairedShortcode("GridColumn", GridColumnComponent);
-  eleventyConfig.addShortcode("PageHeader", PageHeaderComponent);
-  eleventyConfig.addShortcode("Pagination", PaginationComponent);
-  eleventyConfig.addShortcode("PrivateResource", ResourcePrivateComponent);
-  eleventyConfig.addShortcode("PublicResource", ResourcePublicComponent);
-  eleventyConfig.addPairedShortcode("ResourceGroup", ResourceGroupComponent);
+  eleventyConfig.addPairedShortcode('Grid', GridComponent);
+  eleventyConfig.addPairedShortcode('GridColumn', GridColumnComponent);
+  eleventyConfig.addShortcode('PageHeader', PageHeaderComponent);
+  eleventyConfig.addShortcode('Pagination', PaginationComponent);
+  eleventyConfig.addShortcode('PrivateResource', ResourcePrivateComponent);
+  eleventyConfig.addShortcode('PublicResource', ResourcePublicComponent);
+  eleventyConfig.addPairedShortcode('ResourceGroup', ResourceGroupComponent);
 
   return {
     // Control which files Eleventy will process
     // e.g.: *.md, *.njk, *.html, *.liquid
     templateFormats: [
-      "md",
-      "njk",
-      "html",
-      "liquid"
+      'md',
+      'njk',
+      'html',
+      'liquid'
     ],
 
     // -----------------------------------------------------------------
     // If your site deploys to a subdirectory, change `pathPrefix`.
     // Don’t worry about leading and trailing slashes, we normalize these.
 
-    // If you don’t have a subdirectory, use "" or "/" (they do the same thing)
+    // If you don’t have a subdirectory, use '' or '/' (they do the same thing)
     // This is only used for link URLs (it does not affect your file structure)
     // Best paired with the `url` filter: https://www.11ty.dev/docs/filters/url/
 
     // You can also pass this in on the command line using `--pathprefix`
 
     // Optional (default is shown)
-    pathPrefix: "/",
+    pathPrefix: '/',
     // -----------------------------------------------------------------
 
     // Pre-process *.md files with: (default: `liquid`)
-    markdownTemplateEngine: "njk",
+    markdownTemplateEngine: 'njk',
 
     // Pre-process *.html files with: (default: `liquid`)
-    htmlTemplateEngine: "njk",
+    htmlTemplateEngine: 'njk',
 
     // Opt-out of pre-processing global data JSON files: (default: `liquid`)
     dataTemplateEngine: false,
 
     // These are all optional (defaults are shown):
     dir: {
-      input: ".",
-      includes: "_includes",
-      data: "_data",
-      output: "_site"
+      input: '.',
+      includes: '_includes',
+      data: '_data',
+      output: '_site'
     }
   };
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,8 @@ module.exports = {
     commonjs: true,
     es2021: true
   },
+  //Since ESLint ignores files beginning with a `.`, we want to explicity tell eslint we want to include the eleventy config file in the linting process.
+  ignorePatterns: '!.eleventy.js',
   extends: ['standard'],
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     commonjs: true,
     es2021: true
   },
-  // Since ESLint ignores files beginning with a `.`, we want to explicity tell eslint we want to include the eleventy config file in the linting process.
+  // Since ESLint ignores files beginning with a `.`, we want to explicity tell eslint to include the eleventy config file in the linting process.
   ignorePatterns: '!.eleventy.js',
   extends: ['standard'],
   overrides: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     commonjs: true,
     es2021: true
   },
-  //Since ESLint ignores files beginning with a `.`, we want to explicity tell eslint we want to include the eleventy config file in the linting process.
+  // Since ESLint ignores files beginning with a `.`, we want to explicity tell eslint we want to include the eleventy config file in the linting process.
   ignorePatterns: '!.eleventy.js',
   extends: ['standard'],
   overrides: [


### PR DESCRIPTION
This PR was created from the linter branch from PR #45 to find a solution to why our `.eleventy.js` is being ignored by the linter This PR addresses the issue of `eslint` automatically ignoring files with a `.` in front of them, such as `.gitignore`, `.eleventy.js`, etc. 

The fix for this is to explicity add `ignorePatterns` to our `eslint` configurations for specific files like this that we don't want ignored during the linting process.