### PR TITLE
Create Section Pages and Section Nav

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,6 +64,14 @@ module.exports = function (eleventyConfig) {
     return (tags || []).filter(tag => ['all', 'nav', 'post', 'posts'].indexOf(tag) === -1);
   })
 
+  // Create a collection for sections in alphabetical title order
+  eleventyConfig.addCollection("sections", function(collection) {
+    return collection.getFilteredByTag("section").sort((a, b) => {
+      return a.data.title.localeCompare(b.data.title);
+    });
+  });
+
+
   // Create an array of all tags
   eleventyConfig.addCollection('tagList', function (collection) {
     const tagSet = new Set();

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,12 +65,11 @@ module.exports = function (eleventyConfig) {
   })
 
   // Create a collection for sections in alphabetical title order
-  eleventyConfig.addCollection("sections", function(collection) {
-    return collection.getFilteredByTag("section").sort((a, b) => {
+  eleventyConfig.addCollection('sections', function (collection) {
+    return collection.getFilteredByTag('section').sort((a, b) => {
       return a.data.title.localeCompare(b.data.title);
     });
   });
-
 
   // Create an array of all tags
   eleventyConfig.addCollection('tagList', function (collection) {

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ This uses whatever NPM and Node version you have installed on your machine, and 
 1. View the site in your browser at [http://localhost:8080](http://localhost:8080)
 
 From here, changes to files will rebuild the site.
+
+## Editing Instructions
+
+### Adding a Section
+
+To add a new section to the site:
+
+1. Add a new Markdown file to the `sections` folder (example: `sections/my-new-section.md`)
+1. At the top of the file, add two lines with `---` and between those two lines put:
+    - `layout: layouts/section`
+    - `title: My New Section's Title`
+1. Add content below the second `---`
+
+Feel free to look at any of the existing sections as a starting point.
+
 ## Checking code before PR
 ### Running Linters
 1. Navigate to the base of this repo

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -1,6 +1,7 @@
 {
   "title": "Bloom Works Guides",
   "url": "https://bloomworks.digital/",
+  "guide": "Bloom Works Guides Template",
   "googlesitevertification" : "",
   "language": "en",
   "robots": "index, follow",

--- a/_includes/components/PageHeader.js
+++ b/_includes/components/PageHeader.js
@@ -1,12 +1,11 @@
 // Strip whitespace
 const { html } = require('common-tags');
 
-function renderPageHeader (subhead, title) {
+function renderPageHeader (title) {
   return html`
     <header role="banner" class="page-header">
       <div class="l-wrapper">
         <h1>
-          ${subhead ? `<span>${subhead}</span>` : ''}
           <span class="sr-only">: </span>
           ${title}
         </h1>

--- a/_includes/layouts/content.njk
+++ b/_includes/layouts/content.njk
@@ -1,4 +1,4 @@
-{% PageHeader subhead, title %}
+{% PageHeader title %}
 
 <main{% if templateClass %} class="{{ templateClass }}"{% endif %} id="content">
   <div class="l-wrapper">

--- a/_includes/layouts/navigation.njk
+++ b/_includes/layouts/navigation.njk
@@ -9,7 +9,7 @@
       <div class="nav-meta">
         <a href="https://bloomworks.digital" aria-label="Bloom Works Logo" class="nav-home">
           {% include "bloom-logo-graphic.svg" %}
-          <strong> {{ guide }}</strong>
+          <strong> {{ metadata.guide }}</strong>
         </a>
       </div>
       <button class="nav-button" data-nav-button="search">

--- a/_includes/layouts/navigation.njk
+++ b/_includes/layouts/navigation.njk
@@ -34,9 +34,9 @@
   </header>
   <section class="dialog-body">
     <ol>
-      {% for chapter in collections[tags] %}
+      {% for section in collections.sections %}
         <li>
-          <a href="{{ chapter.page.url }}">{{ chapter.data.title }}</a>
+          <a href="{{ section.page.url }}">{{ section.data.title }}</a>
         </li>
       {% endfor %}
     </ol>

--- a/_includes/layouts/navigation.njk
+++ b/_includes/layouts/navigation.njk
@@ -36,7 +36,7 @@
     <ol>
       {% for chapter in collections[tags] %}
         <li>
-          <a href="{{ chapter.page.url }}">{% if chapter.data.subhead %}{{ chapter.data.subhead }}: {% endif %}{{ chapter.data.title }}</a>
+          <a href="{{ chapter.page.url }}">{{ chapter.data.title }}</a>
         </li>
       {% endfor %}
     </ol>

--- a/_includes/layouts/section.njk
+++ b/_includes/layouts/section.njk
@@ -1,0 +1,5 @@
+---
+tags: section
+guide: Guides Template OVERRIDE
+---
+{% include "layouts/base.njk" %}

--- a/_includes/layouts/section.njk
+++ b/_includes/layouts/section.njk
@@ -1,5 +1,4 @@
 ---
 tags: section
-guide: Guides Template OVERRIDE
 ---
 {% include "layouts/base.njk" %}

--- a/components/page-header.md
+++ b/components/page-header.md
@@ -6,4 +6,4 @@ title: "About the Playbook"
 {% include "layouts/head.njk" %}
 {% include "layouts/seo.njk" %}
 {% include "layouts/css.njk" %}
-{%- PageHeader subhead, title -%}
+{%- PageHeader title -%}

--- a/index.njk
+++ b/index.njk
@@ -1,9 +1,6 @@
 ---
-layout: layouts/section
-eleventyNavigation:
-  key: Home
-guide: Bloom Works Guides
-title: Page Title
+layout: layouts/base
+title: Home
 ---
 
 <h1>Heading 1</h1>

--- a/index.njk
+++ b/index.njk
@@ -1,11 +1,9 @@
 ---
-layout: layouts/base.njk
+layout: layouts/section
 eleventyNavigation:
   key: Home
-  order: 1
 guide: Bloom Works Guides
 title: Page Title
-subhead: Subhead
 ---
 
 <h1>Heading 1</h1>

--- a/sections/another-test-section.md
+++ b/sections/another-test-section.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/section
+title: Another Test Section
+---
+
+# Another Test Section
+
+Yet, more test content...

--- a/sections/another-test-section.md
+++ b/sections/another-test-section.md
@@ -3,6 +3,6 @@ layout: layouts/section
 title: Another Test Section
 ---
 
-# Another Test Section
+# Header 1
 
 Yet, more test content...

--- a/sections/test-section.md
+++ b/sections/test-section.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/section
+title: Test Section
+---
+
+# Test Section
+
+Test content!

--- a/sections/test-section.md
+++ b/sections/test-section.md
@@ -3,6 +3,6 @@ layout: layouts/section
 title: Test Section
 ---
 
-# Test Section
+# Header 1
 
 Test content!


### PR DESCRIPTION
## Pull Request Background

Previously, there wasn't a clear way to add a new page to the Sections navigation unless it happened to have the same tag as the currently viewed page. This makes an explicit `sections` folder and `section` layout type for adding new sections to the guide. Additionally, displays the section pages in alphabetical order in the navigation.

### What Changed

- Adds a `section` layout
- Adds a `section` folder for storing section pages
- The navigation displays all section pages in alphabetical order by the pages' `title` data
- Removes `subhead` from page data since sections probably don't need this
- Removes `guide` data type, and centralizes it (i.e. each section page doesn't need this configured)
- Documentation on how to add a new section

### How to Check Change

- [ ] Bring up the site and verify that the two pages within the `sections` folder are displayed and navigable to
- [ ] Add a new section page per the added documentation in the README

