### PR TITLE
Tests setup relocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,12 @@ RUN npm install
 RUN apt-get update && apt-get install -y \
   pip && pip install djlint==1.31.1
 
-# Install dependencies for cypress axe-core e2e testing
-RUN npm install cypress && npm install axe-core
+# Install tools for functional tests
+RUN npx playwright install --with-deps
+
+# Install tools for accessibility tests
+RUN node_modules/.bin/cypress install
+
 
 # Run a server if executing the container (Port 8080 is default)
 ARG PORT=8080

--- a/README.md
+++ b/README.md
@@ -76,10 +76,7 @@ We are using [Cypress](https://docs.cypress.io/guides/overview/why-cypress) and 
 1. Navigate to the base of this repo and run `npx cypress run` for tests to execute in the command line. To execute tests in Cypress' UI window, run `npx cypress open` and select E2E testing.
 1. We have added functionality that will print an error table in the command line on test execution. This table includes the name and description of the error along with a `helpUrl` containing a URL where more information on how to fix that particular error can be found. Additionally, you can visit the official [axe-core rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md) github to view the different axe-core rule descriptions.
 1. Cypress captures snapshots at the time of test execution, these can be viewed by navigating to the `cypress/screenshots` folder.
+
 ### **Additional Notes on Cypress Testing for Local Development
 
 - During local development, it is important to restart your server if you're making code or package changes while http://localhost:8080 is still running. This will ensure the Cypress tests are running and passing correctly in your local environment.
-
-- If you are running Cypress tests in Docker and/or on a virtual machine, there are [additional dependencies](https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies) you will need to install depending on what type of environment you have.
-
-- If you are running Docker on your machine and get an error that `Cypress is not installed` and that it cannot find the cypress file at `/root/.cache/Cypress/12.17.1/Cypress`, this could be a permissions issue and you would run `node_modules/.bin/cypress install` inside of the Docker container to install Cypress.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ We are using [Cypress](https://docs.cypress.io/guides/overview/why-cypress) and 
 ### **Additional Notes on Cypress Testing for Local Development
 
 - During local development, it is important to restart your server if you're making code or package changes while http://localhost:8080 is still running. This will ensure the Cypress tests are running and passing correctly in your local environment.
+- If you are running Cypress tests in Docker and/or on a virtual machine, there are [additional dependencies](https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies) you will need to install depending on what type of environment you have.
+- If you are running Docker on your machine and get an error that `Cypress is not installed` and that it cannot find the cypress file at `/root/.cache/Cypress/12.17.1/Cypress`, this could be a permissions issue and you would run `node_modules/.bin/cypress install` inside of the Docker container to install Cypress.

--- a/ci/tests.sh
+++ b/ci/tests.sh
@@ -1,17 +1,11 @@
 # Fail if any command exits with a non-zero exit code
 set -e
 
-# -----
-# REPLACE THE BELOW WITH YOUR COMMANDS
-# -----
 echo 'Run Node tests'
 # Run Playwright tests
-npx playwright install --with-deps
 npx playwright test
 
 echo 'Run accessibility tests'
 # Run Cypress accessibility tests
-# Installing wait-on ensures the application is up and running before Cypress.
-npm install -g wait-on
-npm run serve & wait-on http://localhost:8080
+npm run serve & npx wait-on http://localhost:8080
 npx cypress run

--- a/package.json
+++ b/package.json
@@ -22,13 +22,16 @@
     "url": "https:/axcora.com/"
   },
   "homepage": "https://eleventy.web.app/",
-  "devDependencies": {
+  "dependencies": {
     "@11ty/eleventy": "2.0.1",
     "@11ty/eleventy-navigation": "0.3.5",
     "@11ty/eleventy-plugin-rss": "1.2.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "5.0.0",
     "@playwright/test": "^1.35.1",
+    "axe-core": "^4.7.2",
+    "common-tags": "^1.8.2",
     "cypress": "^12.17.0",
+    "cypress-axe": "^1.4.0",
     "eleventy-plugin-nesting-toc": "^1.3.0",
     "eslint": "^8.44.0",
     "eslint-config-standard": "^17.1.0",
@@ -39,11 +42,7 @@
     "markdown-it": "13.0.1",
     "markdown-it-anchor": "8.6.7",
     "stylelint": "^15.9.0",
-    "stylelint-config-standard": "^33.0.0"
-  },
-  "dependencies": {
-    "axe-core": "^4.7.2",
-    "common-tags": "^1.8.2",
-    "cypress-axe": "^1.4.0"
+    "stylelint-config-standard": "^33.0.0",
+    "wait-on": "^7.0.1"
   }
 }


### PR DESCRIPTION
## Pull Request Background

Moved test setup steps into the Docker container to enable those steps to be re-used across runs without having to do a reinstall each time the container starts up.

### What Changed

- Installation steps moved into the container setup
- package.json: Moved devDependencies into dependencies to enable easier installation and since the only reason the container would be used is for builds/dev (i.e. devDependencies are most useful for when trying to keep an image slim for production, but this container doesn't run the site for prod)
- Removed documentation on running Cypress in Docker, since those steps are build into the setup

### How to Check Change

- [ ] Functional and accessibility tests should run as they did before
