### PR TITLE
Backport fixes from Handbook

### DIFF
--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Bloom Works Guides",
-  "url": "https://bloomworks.digital/",
+  "url": "/",
   "guide": "Bloom Works Guides Template",
   "googlesitevertification" : "",
   "language": "en",

--- a/_includes/css/components/page-header.css
+++ b/_includes/css/components/page-header.css
@@ -5,7 +5,6 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: calc(var(--t-leading-rem) * 4) 1rem;
   margin-block-end: calc(var(--t-leading-rem) * 2);
   position: relative;
   background: var(--c-accent);

--- a/_includes/layouts/navigation.njk
+++ b/_includes/layouts/navigation.njk
@@ -7,7 +7,7 @@
       <span>Sections</span>
       </button>
       <div class="nav-meta">
-        <a href="https://bloomworks.digital" aria-label="Bloom Works Logo" class="nav-home">
+        <a href="{{ metadata.url }}" aria-label="Bloom Works Logo" class="nav-home">
           {% include "bloom-logo-graphic.svg" %}
           <strong> {{ metadata.guide }}</strong>
         </a>


### PR DESCRIPTION
Long overdue backport of fixes from the Handbook:

- Makes the header smaller, since we're likely not going to have "hero" images for each page
- Makes the name of the guide link at the top of the page direct back to the guide's home